### PR TITLE
Ensure realpath and gawk are installed

### DIFF
--- a/build-config/Makefile
+++ b/build-config/Makefile
@@ -323,7 +323,7 @@ machine-prefix:
 DEBIAN_BUILD_HOST_PACKAGES	= build-essential stgit u-boot-tools python-sphinx rst2pdf \
 				  gperf device-tree-compiler python-all-dev genisoimage \
 				  syslinux-common autoconf automake bison flex texinfo libtool \
-				  lib32ncurses5-dev
+				  lib32ncurses5-dev realpath gawk
 
 PHONY += debian-prepare-build-host
 debian-prepare-build-host:


### PR DESCRIPTION
realpath is required for patching linux and gawk is required for the build

```
==== patching  Linux ====
/home/debian/work/onie/build-config/scripts/cp-machine-patches: line 30: realpath: command not found
/home/debian/work/onie/build-config/scripts/cp-machine-patches: line 31: realpath: command not found
/home/debian/work/onie/build-config/scripts/cp-machine-patches: line 32: realpath: command not found
/home/debian/work/onie/build-config/scripts/cp-machine-patches: line 70: : No such file or directory
make: *** [/home/debian/work/onie/build/fsl_p2020rdbpca-r0/stamp/kernel-patch] Error 1

make: *** Waiting for unfinished jobs....
```
